### PR TITLE
Improvement and tests for olsrd1parser

### DIFF
--- a/netdiff/olsr1.py
+++ b/netdiff/olsr1.py
@@ -10,7 +10,7 @@ class Olsr1Parser:
             self.parse(graph=self.old_graph, data=old)
         if new:
             self.parse(graph=self.new_graph, data=new)
-    
+
     def parse(self, graph, data):
         if type(data) is not dict:
             data = json.loads(data)
@@ -19,9 +19,17 @@ class Olsr1Parser:
                            link["destinationIP"],
                            weight=link["tcEdgeCost"])
         return graph
-       
+
     def diff(self):
+        def difference(old, new):
+            diff = old.copy()
+            diff.remove_edges_from(n for n in old.edges() if n in new.edges())
+            return diff
+
+
         return {
-            "added": networkx.difference(self.new_graph, self.old_graph),
-            "removed": networkx.difference(self.old_graph, self.new_graph)
+            "added": difference(old = self.new_graph,
+                                new = self.old_graph),
+            "removed": difference(old = self.old_graph,
+                                new = self.new_graph)
         }

--- a/tests/olsr1/Olsr_graph_gen.py
+++ b/tests/olsr1/Olsr_graph_gen.py
@@ -1,0 +1,41 @@
+import json
+import networkx as nx
+import random
+
+
+
+class OlsrGraphGen:
+	def __init__(self, seed):
+		self.parse_olsr_topo(seed)
+	#olsr json to networkx
+	def parse_olsr_topo(self, data):
+		self.graph = nx.MultiGraph()
+		if type(data) is not dict:
+			data = json.loads(data)
+		for link in data["topology"]:
+			self.graph.add_edge(link["lastHopIP"],
+						link["destinationIP"],
+						weight=link["tcEdgeCost"])
+		return self.graph
+
+	def reduce_graph(self, new_size):
+		size_diff = len(self.graph) - new_size
+		if size_diff <= 0:
+			print ("Your reduced graph is larger than the original:", len(self.graph))
+			sys.exit(1)
+		for i in range(1000):
+			#Let's do 1000 attempts to find a random subgraph of
+			#the chosen size, else we give up
+			test_graph = self.graph.copy()
+			new_nodes = random.sample(self.graph.nodes(), new_size)
+			new_graph = test_graph.subgraph(new_nodes)
+			if nx.is_connected(new_graph):
+				return new_graph
+		return None
+
+	#networkx to olsr json
+	def gen_olsr_topo(self, graph):
+		data = {"topology": []}
+		for n in graph.edges(data=True):
+			data["topology"].append({"lastHopIP" : n[0], "destinationIP" : n[1], "tcEdgeCost" : n[2]['weight']})# to fix etx
+		return json.dumps(data,indent=1)

--- a/tests/olsr1/tests.py
+++ b/tests/olsr1/tests.py
@@ -1,6 +1,9 @@
 import os
 import unittest
+import random
+import networkx as nx
 from netdiff.olsr1 import Olsr1Parser
+from .Olsr_graph_gen import OlsrGraphGen
 
 
 __all__ = ['TestOlsr1Parser']
@@ -11,9 +14,26 @@ topology1 = open('{0}/topology1.json'.format(CURRENT_DIR)).read()
 
 
 class TestOlsr1Parser(unittest.TestCase):
+    og = OlsrGraphGen(topology1)
     def test_nochanges(self):
         parser = Olsr1Parser(old=topology1, new=topology1)
         result = parser.diff()
         self.assertTrue(type(result) is dict)
         # TODO:
         # ensure added and removed have 0 changes
+
+    def test_different_leo(self):
+        for n in range(20,len(self.og.graph)):
+            parser = Olsr1Parser(old = topology1, new = self.og.gen_olsr_topo(self.og.reduce_graph(n)))
+            result = parser.diff()
+            self.assertFalse((len(result['removed'].edges())==0) and
+                             (len(result['added'].edges())==0))
+        self.assertTrue(1)
+
+    def small_graph_test(self):
+        old_graph = self.og.gen_olsr_topo(self.og.reduce_graph(10))
+        new_graph = self.og.gen_olsr_topo(self.og.reduce_graph(15))
+        parser = Olsr1Parser(old=old_graph, new = new_graph)
+        result = parser.diff();
+        self.assertTrue((len(result['removed'].edges())>0) or
+                         (len(result['added'].edges())>0))


### PR DESCRIPTION
I've corrected the diff function. the networkx.difference function is not usable to make the diff beetween two graph with different node sets. I've implemented the difference between to graph, removing the node that are in graph a from graph b.

I've created a Subgraph generator using the @leonardomaccari function.

With this function i've built a test for olsr1parser
