### PR TITLE
[netjson] Add directed graph support for NetJsonParser

### DIFF
--- a/netdiff/parsers/base.py
+++ b/netdiff/parsers/base.py
@@ -1,6 +1,7 @@
 import json
 import telnetlib
 
+import networkx
 import requests
 import six
 
@@ -26,7 +27,7 @@ class BaseParser(object):
 
     def __init__(self, data=None, url=None, file=None,
                  version=None, revision=None, metric=None,
-                 timeout=None, verify=True):  # noqa
+                 timeout=None, verify=True, directed=False):  # noqa
         """
         Initializes a new Parser
 
@@ -38,6 +39,8 @@ class BaseParser(object):
         :param metric: routing protocol metric
         :param timeout: timeout in seconds for HTTP or telnet requests
         :param verify: boolean (valid for HTTPS requests only)
+        :param directed: whether the resulting graph should be directed
+                         (undirected by default for backwards compatibility)
         """
         if version:
             self.version = version
@@ -47,6 +50,7 @@ class BaseParser(object):
             self.metric = metric
         self.timeout = timeout
         self.verify = verify
+        self.directed = directed
         if data is None and url is not None:
             data = self._get_url(url)
         elif data is None and file is not None:
@@ -116,6 +120,9 @@ class BaseParser(object):
         data = tn.read_all().decode('ascii')
         tn.close()
         return data
+
+    def _init_graph(self):
+        return networkx.DiGraph() if self.directed else networkx.Graph()
 
     def parse(self, data):
         """

--- a/netdiff/parsers/netjson.py
+++ b/netdiff/parsers/netjson.py
@@ -1,5 +1,3 @@
-import networkx
-
 from ..exceptions import ParserError
 from .base import BaseParser
 
@@ -13,7 +11,7 @@ class NetJsonParser(BaseParser):
         to a NetworkX Graph object,which is then returned.
         Additionally checks for protocol version, revision and metric.
         """
-        graph = networkx.Graph()
+        graph = self._init_graph()
         # ensure is NetJSON NetworkGraph object
         if 'type' not in data or data['type'] != 'NetworkGraph':
             raise ParserError('Parse error, not a NetworkGraph object')


### PR DESCRIPTION
Lack of support for directed graphs is a problem for NetJsonParser in particular because it is possible to receive a NetJson-formatted file which represents a directed graph, then have that information be lost or, worse, incorrectly parsed. I have been hacking a DiGraph into NetJsonParser objects in my client application for awhile, but maybe it is time for those to be officially supported :)

It should be easily possible to follow the same pattern for the other parsers to allow them to be directed or undirected, but I don't know how to represent directed graphs in other protocols or they even allow directed graphs