### PR TITLE
[enhancement] Drop support python2 #81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,20 @@ language: python
 cache: pip
 
 python:
-  - "3.5"
-  - "2.7"
+  - "3.6"
+  - "3.7"
 
 branches:
   only:
     - master
 
-# command to install requirements
 install:
   - python setup.py -q develop
   - pip install -r requirements-test.txt
 
-# command to run qa-checks
 before_script:
   - openwisp-utils-qa-checks --skip-checkmigrations --skip-checkmakemigrations
 
-# command to run tests, e.g. python setup.py test
 script:
   - nosetests --with-coverage --cover-package=netdiff
 

--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ The data which was retrieved from network/storage can be accessed via the "data"
 
     def to_python(self, data):
         try:
-            return super(OlsrParser, self).to_python(data)
+            return super().to_python(data)
         except ConversionException as e:
             return self._txtinfo_to_jsoninfo(e.data)
 

--- a/netdiff/parsers/base.py
+++ b/netdiff/parsers/base.py
@@ -3,7 +3,6 @@ import telnetlib
 
 import networkx
 import requests
-import six
 
 from ..exceptions import ConversionException, TopologyRetrievalError
 from ..utils import _netjson_networkgraph, diff
@@ -85,7 +84,7 @@ class BaseParser(object):
         """
         if isinstance(data, dict):
             return data
-        elif isinstance(data, six.string_types):
+        elif isinstance(data, str):
             # assuming is JSON
             try:
                 return json.loads(data)

--- a/netdiff/parsers/batman.py
+++ b/netdiff/parsers/batman.py
@@ -16,7 +16,7 @@ class BatmanParser(BaseParser):
         Adds support for txtinfo format
         """
         try:
-            return super(BatmanParser, self).to_python(data)
+            return super().to_python(data)
         except ConversionException as e:
             return self._txtinfo_to_python(e.data)
 

--- a/netdiff/parsers/cnml.py
+++ b/netdiff/parsers/cnml.py
@@ -1,7 +1,6 @@
 import os
 
 import libcnml
-import six
 
 from ..exceptions import ParserError
 from .base import BaseParser
@@ -19,7 +18,7 @@ class CnmlParser(BaseParser):
     metric = None
 
     def to_python(self, data):
-        if isinstance(data, six.string_types):
+        if isinstance(data, str):
             up = urlparse.urlparse(data)
             # if it looks like a file path
             if os.path.isfile(data) or up.scheme in ['http', 'https']:

--- a/netdiff/parsers/olsr.py
+++ b/netdiff/parsers/olsr.py
@@ -13,7 +13,7 @@ class OlsrParser(BaseParser):
         Adds support for txtinfo format
         """
         try:
-            return super(OlsrParser, self).to_python(data)
+            return super().to_python(data)
         except ConversionException as e:
             return self._txtinfo_to_jsoninfo(e.data)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 nose
 coveralls
 responses>0.5.0,<0.11.0
-mock
-openwisp-utils[qa]>=0.3.0
+openwisp-utils[qa]>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests<3.0
-six
 libcnml<0.10.0
 openvpn-status>=0.2,<0.3

--- a/runisort
+++ b/runisort
@@ -1,1 +1,0 @@
-isort --check-only --recursive --diff .

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,7 @@ def get_install_requires():
             continue
         # add line to requirements
         requirements.append(line.replace('\n', ''))
-    if sys.version_info.major >= 3:
         requirements.append("networkx>=2.0,<2.5")
-    else:
-        requirements.append("networkx>=2.0,<2.3")
     return requirements
 
 
@@ -71,8 +68,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: System :: Networking',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3',
     ],
     install_requires=get_install_requires(),
     test_suite='nose.collector'

--- a/tests/test_batman.py
+++ b/tests/test_batman.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import BatmanParser, diff
 from netdiff.exceptions import ParserError
@@ -67,7 +66,7 @@ class TestBatmanParser(TestCase):
     def test_json_string(self):
         p = BatmanParser(iulinet)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_batman_txtinfo.py
+++ b/tests/test_batman_txtinfo.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import BatmanParser, diff
 from netdiff.exceptions import ParserError
@@ -43,7 +42,7 @@ class TestBatmanTxtinfoParser(TestCase):
     def test_json_string(self):
         p = BatmanParser(iulinet)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_bmx6.py
+++ b/tests/test_bmx6.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import Bmx6Parser, diff
 from netdiff.exceptions import ParserError
@@ -49,7 +48,7 @@ class TestBmx6Parser(TestCase):
     def test_json_string(self):
         p = Bmx6Parser(topo)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_cnml.py
+++ b/tests/test_cnml.py
@@ -2,7 +2,6 @@ import os
 
 import libcnml
 import networkx
-import six
 
 from netdiff import CnmlParser, diff
 from netdiff.exceptions import ParserError
@@ -41,7 +40,7 @@ class TestCnmlParser(TestCase):
     def test_json_string(self):
         p = CnmlParser(cnml1)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_netjson.py
+++ b/tests/test_netjson.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import NetJsonParser, diff
 from netdiff.exceptions import ParserError
@@ -26,7 +25,7 @@ class TestNetJsonParser(TestCase):
         # test additional properties in nodes of networkx graph
         properties = list(p.graph.nodes(data=True))[0][1]
         self.assertIsInstance(properties['local_addresses'], list)
-        self.assertIsInstance(properties['hostname'], six.string_types)
+        self.assertIsInstance(properties['hostname'], str)
 
     def test_parse_directed(self):
         p = NetJsonParser(links2, directed=True)
@@ -40,7 +39,7 @@ class TestNetJsonParser(TestCase):
         # test additional properties in nodes of networkx graph
         properties = list(p.graph.nodes(data=True))[0][1]
         self.assertIsInstance(properties['local_addresses'], list)
-        self.assertIsInstance(properties['hostname'], six.string_types)
+        self.assertIsInstance(properties['hostname'], str)
 
     def test_parse_string_graph(self):
         data = """{
@@ -229,7 +228,7 @@ class TestNetJsonParser(TestCase):
     def test_json_string(self):
         p = NetJsonParser(links2)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_olsr.py
+++ b/tests/test_olsr.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import OlsrParser, diff
 from netdiff.exceptions import ParserError
@@ -81,7 +80,7 @@ class TestOlsrParser(TestCase):
     def test_json_string(self):
         p = OlsrParser(links2)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)

--- a/tests/test_olsr_txtinfo.py
+++ b/tests/test_olsr_txtinfo.py
@@ -1,7 +1,6 @@
 import os
 
 import networkx
-import six
 
 from netdiff import OlsrParser, diff
 from netdiff.exceptions import ParserError
@@ -70,7 +69,7 @@ class TestOlsrTxtinfoParser(TestCase):
     def test_json_string(self):
         p = OlsrParser(links2)
         data = p.json()
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
         self.assertIn('NetworkGraph', data)
         self.assertIn('protocol', data)
         self.assertIn('version', data)


### PR DESCRIPTION
Removed Python2 and it's supported structures.

* Simplified `Super()`
* Upgraded `openwisp-utils` to 0.4.0
* Removed `six`

Closes #81