### PR TITLE
[chores] Improved solution of OpenVPN parsing bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,17 @@ Changelog
 Version 0.8.0 [unreleased]
 --------------------------
 
-- Detect changes in nodes and links
-- Added/remove/changed nodes/links are now sorted
-- Unspecified fields like node's label and link's cost_text are now always
+- Fix: fixed parsing issue in OpenVPN which caused some node and links to
+  be missed if the OpenVPN nodes had same IP but different ports
+- Feature: detect changes in nodes and links
+- Change: Added/remove/changed nodes/links are now sorted
+- Change: Unspecified fields like node's label and link's ``cost_text`` are now always
   shown as empty string if they are not specified
-- Parse cost_text field from links
-
-NOTE: The output of ``diff`` in this release differs from the previous ones.
-The previous fields haven't been changed but new ones have been added.
+- Change: Parse ``cost_text`` field from links
+- **Backward incompatible change**: the output of ``diff`` in this release differs
+  slightly from the previous versions.
+  Applications using previous netdiff versions will likely need minor adjustments
+  to their code
 
 Version 0.7.0 [15-01-2020]
 --------------------------

--- a/tests/test_openvpn.py
+++ b/tests/test_openvpn.py
@@ -133,11 +133,11 @@ class TestOpenvpnParser(TestCase):
         for link in data['links']:
             targets.append(link['target'])
         expected = [
-            '185.211.160.5:56114',
-            '185.211.160.87:53356',
+            '185.211.160.5',
+            '185.211.160.87',
             '194.183.10.51:49794',
             '194.183.10.51:60003',
-            '195.94.160.52:20086',
-            '217.72.97.67:59908',
+            '195.94.160.52',
+            '217.72.97.67',
         ]
         self.assertEqual(expected, targets)


### PR DESCRIPTION
node ID will be always just the host unless
there are multiple hosts with the same address,
in which case host:port will be used.

This makes the network graph cleaner because ports
can change often in OpenVPN and as a result the graph
will show new nodes when in the truth is always
the same node on a different port.

Updated changelog.