### PR TITLE
0.8.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Version 0.8.0 [unreleased]
+Version 0.8.0 [21-06-2020]
 --------------------------
 
 - Fix: fixed parsing issue in OpenVPN which caused some node and links to
@@ -15,6 +15,8 @@ Version 0.8.0 [unreleased]
   slightly from the previous versions.
   Applications using previous netdiff versions will likely need minor adjustments
   to their code
+- Documentation Improvements
+- Added support for openwisp-utils~=0.5.0
 
 Version 0.7.0 [15-01-2020]
 --------------------------

--- a/netdiff/info.py
+++ b/netdiff/info.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0, 'final')
+VERSION = (0, 8, 0, 'final')
 __version__ = VERSION
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 nose2[coverage_plugin]>=0.6.5
 coveralls
 responses>0.5.0,<0.11.0
-openwisp-utils[qa]>=0.5.0
+openwisp-utils[qa]~=0.5.0


### PR DESCRIPTION
- Fix: fixed parsing issue in OpenVPN which caused some node and links to
  be missed if the OpenVPN nodes had same IP but different ports
- Feature: detect changes in nodes and links
- Change: Added/remove/changed nodes/links are now sorted
- Change: Unspecified fields like node's label and link's ``cost_text`` are now always
  shown as empty string if they are not specified
- Change: Parse ``cost_text`` field from links
- **Backward incompatible change**: the output of ``diff`` in this release differs
  slightly from the previous versions.
  Applications using previous netdiff versions will likely need minor adjustments
  to their code
- Documentation Improvements
- Added support for openwisp-utils~=0.5.0

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>