### PR TITLE
[bug] Fix parsing of latest OLSR jsoninfo format

### DIFF
--- a/netdiff/parsers/olsr.py
+++ b/netdiff/parsers/olsr.py
@@ -31,7 +31,10 @@ class OlsrParser(BaseParser):
             raise ParserError('Parse error, "mid" key not found')
 
         # determine version and revision
-        if 'config' in data:
+        if 'version' in data:
+            self.version = data['version']['releaseVersion']
+            self.revision = data['version']['sourceHash']
+        elif 'config' in data:
             version_info = data['config']['olsrdVersion'].replace(' ', '').split('-')
             self.version = version_info[1]
             # try to get only the git hash
@@ -43,7 +46,10 @@ class OlsrParser(BaseParser):
         alias_dict = {}
         for node in data['mid']:
             local_addresses = [alias['ipAddress'] for alias in node['aliases']]
-            alias_dict[node['ipAddress']] = local_addresses
+            if 'main' in node:
+                alias_dict[node['main']['ipAddress']] = local_addresses
+            else:
+                alias_dict[node['ipAddress']] = local_addresses
 
         # loop over topology section and create networkx graph
         for link in data['topology']:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@ nose2[coverage_plugin]>=0.6.5
 coveralls
 responses>0.5.0,<0.11.0
 openwisp-utils[qa]~=0.5.0
-parameterized
+parameterized~=0.8.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ nose2[coverage_plugin]>=0.6.5
 coveralls
 responses>0.5.0,<0.11.0
 openwisp-utils[qa]~=0.5.0
+parameterized

--- a/tests/static/olsr-2-links-newformat.json
+++ b/tests/static/olsr-2-links-newformat.json
@@ -1,0 +1,193 @@
+{
+    "topology": [
+        {
+            "lastHopIP": "10.150.0.2",
+            "destinationIP": "10.150.0.3",
+            "linkQuality": 0.195,
+            "neighborLinkQuality": 0.184,
+            "tcEdgeCost": 28334,
+            "validityTime": 284572
+        },
+        {
+            "lastHopIP": "10.150.0.3",
+            "destinationIP": "10.150.0.4",
+            "linkQuality": 1.0,
+            "neighborLinkQuality": 1.0,
+            "tcEdgeCost": 1024,
+            "validityTime": 284572
+        }
+    ],
+    "mid": [
+        {
+            "main": {
+                "ipAddress": "10.150.0.2",
+                "validityTime": 286445
+            },
+            "aliases": [
+                {
+                    "ipAddress": "172.16.192.2",
+                    "validityTime": 286445
+                },
+                {
+                    "ipAddress": "192.168.0.2",
+                    "validityTime": 286445
+                }
+            ]
+        },
+        {
+            "main": {
+                "ipAddress": "10.150.0.3",
+                "validityTime": 286445
+            },
+            "aliases": [
+                {
+                    "ipAddress": "172.16.192.3",
+                    "validityTime": 286445
+                }
+            ]
+        },
+        {
+            "main": {
+                "ipAddress": "10.150.0.4",
+                "validityTime": 286445
+            },
+            "aliases": [
+                {
+                    "ipAddress": "172.16.192.4",
+                    "validityTime": 286445
+                }
+            ]
+        }
+    ],
+    "version": {
+        "version": "olsr.org - 0.6.6-git_0000000-hash_5031a799fcbe17f61d57e387bc3806de",
+        "gitDescriptor": "",
+        "gitSha": "0000000000000000000000000000000000000000",
+        "releaseVersion": "0.6.6",
+        "sourceHash": "5031a799fcbe17f61d57e387bc3806de"
+    },
+    "config": {
+        "olsrPort":698,
+        "debugLevel":0,
+        "noFork":false,
+        "pidFile": "",
+        "hostEmulation":false,
+        "ipVersion":2,
+        "allowNoInt": true,
+        "tosValue": 192,
+        "rtProto":3,
+        "rtTable": {
+            "main": 222,
+            "default": 223,
+            "tunnel": 223,
+            "priority": -1,
+            "tunnelPriority": -1,
+            "defaultOlsrPriority": -1,
+            "defaultPriority": -1
+        },
+        "willingness": {
+            "willingness": 3,
+            "auto": false,
+            "updateInterval": 20
+        },
+        "brokenLinkCost":4194304,
+        "brokenRouteCost":-1,
+        "fib": {
+            "metric": "flat",
+            "metricDefault": "approx"
+        },
+        "hna": [
+            {
+                "destination":"10.176.0.128",
+                "genmask":25,
+                "gateway":"10.0.1.77",
+                "validityTime": 0
+            }
+        ],
+        "interfaceDefaults": {
+            "ipv4Broadcast": "255.255.255.255",
+            "ipv6Multicast": "ff02::6d",
+            "ipv4Source": "0.0.0.0",
+            "ipv6Source": "0.0.0.0",
+            "ipv6SourcePrefixLength": 0,
+            "mode": "mesh",
+            "weightValue": 0,
+            "weightFixed": false,
+            "hello": {
+              "emissionInterval": 5,
+              "validityTime": 100
+            },
+            "tc": {
+              "emissionInterval": 3,
+              "validityTime": 500
+            },
+            "mid": {
+              "emissionInterval": 30,
+              "validityTime": 500
+            },
+            "hna": {
+              "emissionInterval": 30,
+              "validityTime": 500
+            },
+            "linkQualityMultipliers": [],
+            "linkQualityMultipliersCount": 0,
+            "autoDetectChanges": true
+        },
+        "ipcConnectMaxConnections": 0,
+        "ipcConnectAllowed": [],
+        "pollRate":50,
+        "nicChgsPollInt": 2.5,
+        "clearScreen":true,
+        "tcRedundancy":2,
+        "mprCoverage":7,
+        "linkQuality": {
+            "level": 2,
+            "fishEye": true,
+            "aging": 0.05,
+            "algorithm": "(null)"
+        },
+        "minTCVTime": 0,
+        "setIpForward":true,
+        "lockFile":"(null)",
+        "useNiit":false,
+        "smartGateway": {
+            "enabled": false
+        },
+        "mainIp":"10.0.1.77",
+        "unicastSourceIpAddress":"10.0.1.77",
+        "srcIpRoutes":false,
+        "maxPrefixLength":32,
+        "ipSize":4,
+        "delgw":false,
+        "maxSendMessageJitter":2.000,
+        "exitValue":0,
+        "maxTcValidTime":5000,
+        "niit4to6InterfaceIndex":0,
+        "niit6to4InterfaceIndex":0,
+        "hasIpv4Gateway":false,
+        "hasIpv6Gateway":false,
+        "ioctlSocket":3,
+        "routeNetlinkSocket":4,
+        "routeMonitorSocket":5,
+        "linkQualityNatThreshold":1.000,
+        "os":"GNU/Linux",
+        "startTime":1430048863
+    },
+    "plugins": [
+        {
+            "plugin": "olsrd_jsoninfo.so.1.1",
+            "parameters": {
+              "accept": "0.0.0.0",
+              "port": "9090"
+            }
+        },      
+        {
+            "plugin": "olsrd_txtinfo.so.0.1",
+            "parameters": {
+              "accept": "0.0.0.0"
+            }
+        }
+    ],
+    "systemTime":1430572557,
+    "timeSinceStartup":523790030
+}

--- a/tests/test_olsr.py
+++ b/tests/test_olsr.py
@@ -1,5 +1,7 @@
 import os
 
+from parameterized import parameterized
+
 import networkx
 
 from netdiff import OlsrParser, diff
@@ -8,6 +10,7 @@ from netdiff.tests import TestCase
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 links2 = open('{0}/static/olsr-2-links.json'.format(CURRENT_DIR)).read()
+links2_newformat = open('{0}/static/olsr-2-links-newformat.json'.format(CURRENT_DIR)).read()
 links2_cost = open(
     '{0}/static/olsr-2-links-cost-changed.json'.format(CURRENT_DIR)
 ).read()
@@ -19,7 +22,8 @@ links5_cost = open(
 
 
 class TestOlsrParser(TestCase):
-    def test_parse(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_parse(self, links2):
         p = OlsrParser(links2)
         self.assertIsInstance(p.graph, networkx.Graph)
         # test additional properties in networkx graph
@@ -51,7 +55,8 @@ class TestOlsrParser(TestCase):
         with self.assertRaises(ParserError):
             OlsrParser('{ "topology": [], "missing_mid": [] }')
 
-    def test_json_dict(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_json_dict(self, links2):
         p = OlsrParser(links2)
         data = p.json(dict=True)
         self.assertIsInstance(data, dict)
@@ -80,7 +85,8 @@ class TestOlsrParser(TestCase):
                 found = True
         self.assertTrue(found)
 
-    def test_json_string(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_json_string(self, links2):
         p = OlsrParser(links2)
         data = p.json()
         self.assertIsInstance(data, str)
@@ -96,7 +102,8 @@ class TestOlsrParser(TestCase):
         self.assertIn('links', data)
         self.assertIn('nodes', data)
 
-    def test_no_changes(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_no_changes(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2)
         result = diff(old, new)
@@ -105,7 +112,8 @@ class TestOlsrParser(TestCase):
         self.assertIsNone(result['removed'])
         self.assertIsNone(result['changed'])
 
-    def test_added_1_link(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_added_1_link(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
         result = diff(old, new)
@@ -128,7 +136,8 @@ class TestOlsrParser(TestCase):
         # ensure correct node added
         self.assertIn('10.150.0.5', result['added']['nodes'][0].values())
 
-    def test_added_1_link_sub(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_added_1_link_sub(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
         result = new - old
@@ -142,7 +151,8 @@ class TestOlsrParser(TestCase):
         # ensure correct node added
         self.assertIn('10.150.0.5', result['added']['nodes'][0].values())
 
-    def test_removed_1_link(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_removed_1_link(self, links2):
         old = OlsrParser(links3)
         new = OlsrParser(links2)
         result = diff(old, new)
@@ -167,7 +177,8 @@ class TestOlsrParser(TestCase):
         # ensure correct node removed
         self.assertIn('10.150.0.5', result['removed']['nodes'][0].values())
 
-    def test_changed_links(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_changed_links(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
         result = diff(old, new)
@@ -181,7 +192,8 @@ class TestOlsrParser(TestCase):
             link['properties'], {'link_quality': 0.195, 'neighbor_link_quality': 0.184}
         )
 
-    def test_changed_nodes(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_changed_nodes(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2_cost)
         result = diff(old, new)
@@ -230,7 +242,8 @@ class TestOlsrParser(TestCase):
         self.assertIn('10.150.0.7', added_nodes)
         self.assertIn('10.150.0.5', result['removed']['nodes'][0].values())
 
-    def test_cost(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_cost(self, links2):
         parser = OlsrParser(links2)
         graph = parser.json(dict=True)
         a = graph['links'][0]['cost']
@@ -259,7 +272,8 @@ class TestOlsrParser(TestCase):
         self.assertIsInstance(data['nodes'], list)
         self.assertIsInstance(data['links'], list)
 
-    def test_cost_changes_1(self):
+    @parameterized.expand([(links2), (links2_newformat)])
+    def test_cost_changes_1(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2_cost)
         result = diff(old, new)

--- a/tests/test_olsr.py
+++ b/tests/test_olsr.py
@@ -1,8 +1,7 @@
 import os
 
-from parameterized import parameterized
-
 import networkx
+from parameterized import parameterized
 
 from netdiff import OlsrParser, diff
 from netdiff.exceptions import ParserError
@@ -10,7 +9,9 @@ from netdiff.tests import TestCase
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 links2 = open('{0}/static/olsr-2-links.json'.format(CURRENT_DIR)).read()
-links2_newformat = open('{0}/static/olsr-2-links-newformat.json'.format(CURRENT_DIR)).read()
+links2_newformat = open(
+    '{0}/static/olsr-2-links-newformat.json'.format(CURRENT_DIR)
+).read()
 links2_cost = open(
     '{0}/static/olsr-2-links-cost-changed.json'.format(CURRENT_DIR)
 ).read()
@@ -21,8 +22,15 @@ links5_cost = open(
 ).read()
 
 
+def parameterized_test_name_func(testcase_func, param_num, param):
+    format = 'newformat' if 'version' in param[0][0] else 'oldformat'
+    return f'{testcase_func.__name__}_{param_num}_{format}'
+
+
 class TestOlsrParser(TestCase):
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_parse(self, links2):
         p = OlsrParser(links2)
         self.assertIsInstance(p.graph, networkx.Graph)
@@ -55,7 +63,9 @@ class TestOlsrParser(TestCase):
         with self.assertRaises(ParserError):
             OlsrParser('{ "topology": [], "missing_mid": [] }')
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_json_dict(self, links2):
         p = OlsrParser(links2)
         data = p.json(dict=True)
@@ -85,7 +95,9 @@ class TestOlsrParser(TestCase):
                 found = True
         self.assertTrue(found)
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_json_string(self, links2):
         p = OlsrParser(links2)
         data = p.json()
@@ -102,7 +114,9 @@ class TestOlsrParser(TestCase):
         self.assertIn('links', data)
         self.assertIn('nodes', data)
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_no_changes(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2)
@@ -112,7 +126,9 @@ class TestOlsrParser(TestCase):
         self.assertIsNone(result['removed'])
         self.assertIsNone(result['changed'])
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_added_1_link(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
@@ -136,7 +152,9 @@ class TestOlsrParser(TestCase):
         # ensure correct node added
         self.assertIn('10.150.0.5', result['added']['nodes'][0].values())
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_added_1_link_sub(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
@@ -151,7 +169,9 @@ class TestOlsrParser(TestCase):
         # ensure correct node added
         self.assertIn('10.150.0.5', result['added']['nodes'][0].values())
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_removed_1_link(self, links2):
         old = OlsrParser(links3)
         new = OlsrParser(links2)
@@ -177,7 +197,9 @@ class TestOlsrParser(TestCase):
         # ensure correct node removed
         self.assertIn('10.150.0.5', result['removed']['nodes'][0].values())
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_changed_links(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links3)
@@ -192,7 +214,9 @@ class TestOlsrParser(TestCase):
             link['properties'], {'link_quality': 0.195, 'neighbor_link_quality': 0.184}
         )
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_changed_nodes(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2_cost)
@@ -242,7 +266,9 @@ class TestOlsrParser(TestCase):
         self.assertIn('10.150.0.7', added_nodes)
         self.assertIn('10.150.0.5', result['removed']['nodes'][0].values())
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_cost(self, links2):
         parser = OlsrParser(links2)
         graph = parser.json(dict=True)
@@ -272,7 +298,9 @@ class TestOlsrParser(TestCase):
         self.assertIsInstance(data['nodes'], list)
         self.assertIsInstance(data['links'], list)
 
-    @parameterized.expand([(links2), (links2_newformat)])
+    @parameterized.expand(
+        [(links2), (links2_newformat)], name_func=parameterized_test_name_func
+    )
     def test_cost_changes_1(self, links2):
         old = OlsrParser(links2)
         new = OlsrParser(links2_cost)


### PR DESCRIPTION
OLSR jsoninfo plugin has changed the JSON output format in some of the "newer" releases. This adds support for parsing that - while remaining backward compatible.